### PR TITLE
Use Snowy Taiga for beta Taiga

### DIFF
--- a/src/main/java/ca/spottedleaf/oldgenerator/generator/b173/BiomeBase173.java
+++ b/src/main/java/ca/spottedleaf/oldgenerator/generator/b173/BiomeBase173.java
@@ -29,7 +29,7 @@ public enum BiomeBase173 {
     },
     SAVANNA(Biome.SAVANNA),
     SHRUBLAND(Biome.PLAINS),
-    TAIGA(Biome.TAIGA) {
+    TAIGA(Biome.SNOWY_TAIGA) {
         @Override
         public WorldGenerator173 getTreeGenerator(Random random) {
             return (random.nextInt(3) == 0 ? new WorldGenTaiga1173() : new WorldGenTaiga2173());


### PR DESCRIPTION
We have been running into some issues with the ice regeneration on [Modern Beta](https://modernbeta.org) — one of our beta gurus pointed out that the beta Taiga biome should map to the modern Snowy Taiga biome instead of regular Taiga.